### PR TITLE
fix: make alternate_contact as optional custom_fields entry

### DIFF
--- a/lambda/aft_alternate_contacts_extract/extract-alternate-contacts.py
+++ b/lambda/aft_alternate_contacts_extract/extract-alternate-contacts.py
@@ -28,6 +28,8 @@ else:
 def extract_custom_fields(payload):
   try:
     raw_data = json.loads(payload['account_request']['custom_fields'])
+    if 'alternate_contact' not in raw_data:
+        return {}
     raw_alternate_contact = json.loads(raw_data['alternate_contact'])
     return raw_alternate_contact
   except Exception as e:

--- a/states/alternate-contacts.asl.json
+++ b/states/alternate-contacts.asl.json
@@ -76,7 +76,7 @@
           "Next": "validate-alternate-contacts"
         }
       ],
-      "Default": "fail"
+      "Default": "skip"
     },
     "validate-alternate-contacts": {
       "Type": "Task",


### PR DESCRIPTION
Issue #3 

*Description of changes:*

change extract-alternate-contacts Lambda to return empty dict when custom_fields for 'alternate_contact' is not present
change alternate-contacts state machine to not process any further if there is no 'alternate_contact' field

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
