### PR TITLE
pegging version as 4 introduced breaking changes

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 3.72"
+      version               = "3.72"
     }
   }
 }


### PR DESCRIPTION
[*Issue #, if available:*](https://github.com/aws-samples/aft-workshop-sample/issues/6)

pegging version as 4 introduced breaking changes - not sure if there are others so pegging to 3.72


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
