### PR TITLE
fix: deprecated aws_subnet_ids

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -6,7 +6,7 @@ data "aws_vpc" "aft_management_vpc" {
   }
 }
 
-data "aws_subnet_ids" "aft_public_subnet_01" {
+data "aws_subnet" "aft_public_subnet_01" {
   count    = var.use_aft_vpc ? 1 : 0
   vpc_id   = data.aws_vpc.aft_management_vpc[count.index].id
   filter {

--- a/main.tf
+++ b/main.tf
@@ -34,5 +34,5 @@ resource "aws_iam_instance_profile" "cloud9-aft-profile" {
 resource "aws_cloud9_environment_ec2" "cloud9-aft" {
   name          = var.c9_instance_name
   instance_type = "t2.small"
-  subnet_id     = local.vpc.is_use_aft_vpc ? tolist(data.aws_subnet_ids.aft_public_subnet_01[local.vpc.index].ids)[0] : null
+  subnet_id     = local.vpc.is_use_aft_vpc ? tolist(data.aws_subnet.aft_public_subnet_01[local.vpc.index].id)[0] : null
 }


### PR DESCRIPTION
*Issue #, if available:*
#6 

*Description of changes:*
Remove deprecated data source `aws_subnet_ids`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
