### PR TITLE
fix: alt-contacts on CT mgt

### DIFF
--- a/iam/role-policies/lambda-aft-alternate-contacts-add-lambda-role-policy.tpl
+++ b/iam/role-policies/lambda-aft-alternate-contacts-add-lambda-role-policy.tpl
@@ -5,7 +5,10 @@
             "Action": [
                 "ssm:GetParameter"
             ],
-            "Resource": "arn:aws:ssm:${data_aws_region}:${data_aws_account_id}:parameter/aft/resources/ddb/aft-request-metadata-table-name",
+            "Resource": [
+                "arn:aws:ssm:${data_aws_region}:${data_aws_account_id}:parameter/aft/resources/ddb/aft-request-metadata-table-name",
+                "arn:aws:ssm:${data_aws_region}:${data_aws_account_id}:parameter/aft/account/ct-management/account-id"
+            ],
             "Effect": "Allow",
             "Sid": "SSMOperations"
         },


### PR DESCRIPTION
*Issue #, if available:*
resolves #5 

*Description of changes:*
Detects if AFT tries to run the provisioning customizations on CT Management Account Id and skip the attempt to update the alternate contacts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
