### PR TITLE
Pin jsonschema to 4.17.3

### DIFF
--- a/lambda/aft_alternate_contacts_validate/requirements.txt
+++ b/lambda/aft_alternate_contacts_validate/requirements.txt
@@ -1,1 +1,1 @@
-jsonschema
+jsonschema==4.17.3


### PR DESCRIPTION
*Issue #, if available:*

Resolve #15 

*Description of changes:*

Ping jsonschema to 4.17.3 for `aft_alternate_contacts_validate`.

User must re-run `make build` to take effect.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
