### PR TITLE
Fix lambda concurrency

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -15,6 +15,10 @@ data "aws_dynamodb_table" "aft_request_metadata_table" {
   name = data.aws_ssm_parameter.aft_request_metadata_table_name.value
 }
 
+data "aws_ssm_parameter" "aft_customizations_max_concurrent" {
+  name = "/aft/config/customizations/maximum_concurrent_customizations"
+}
+
 data "archive_file" "aft_alternate_contacts_extract" {
   type        = "zip"
   source_dir  = "${path.module}/lambda/aft_alternate_contacts_extract"

--- a/lambda.tf
+++ b/lambda.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "aft_alternate_contacts_extract_lambda" {
   tracing_config {
     mode = "Active"
   }
-  reserved_concurrent_executions = 1
+  reserved_concurrent_executions = data.aws_ssm_parameter.aft_customizations_max_concurrent.value
 }
 
 resource "aws_cloudwatch_log_group" "aft_alternate_contacts_extract_lambda_log" {
@@ -33,7 +33,7 @@ resource "aws_lambda_function" "aft_alternate_contacts_add_lambda" {
   tracing_config {
     mode = "Active"
   }
-  reserved_concurrent_executions = 1
+  reserved_concurrent_executions = data.aws_ssm_parameter.aft_customizations_max_concurrent.value
 }
 
 resource "aws_cloudwatch_log_group" "aft_alternate_contacts_add_lambda_log" {
@@ -53,7 +53,7 @@ resource "aws_lambda_function" "aft_alternate_contacts_validate_lambda" {
   tracing_config {
     mode = "Active"
   }
-  reserved_concurrent_executions = 1
+  reserved_concurrent_executions = data.aws_ssm_parameter.aft_customizations_max_concurrent.value
 }
 
 resource "aws_cloudwatch_log_group" "aft_alternate_contacts_validate_lambda_log" {


### PR DESCRIPTION
*Issue #, if available:*

Resolves #14 

*Description of changes:*

* AFT by default has max concurrency of 5 parallel pipeline. This fix will adhere the AFT Alternate Contact lambda concurrency to this default value.
* **Warning:**: this wont fix the problem if customer modifies the max parallel pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
